### PR TITLE
Fix bug in original VPN DNS leak solution

### DIFF
--- a/server/NetworkController.cpp
+++ b/server/NetworkController.cpp
@@ -209,8 +209,8 @@ int NetworkController::setDefaultNetwork(unsigned netId) {
 
 uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) const {
     Fwmark fwmark;
-    fwmark.protectedFromVpn = true;
-    fwmark.permission = PERMISSION_SYSTEM;
+    fwmark.protectedFromVpn = canProtectLocked(uid, *netId);
+    fwmark.permission = getPermissionForUserLocked(uid);
 
     Network* appDefaultNetwork = getPhysicalOrUnreachableNetworkForUserLocked(uid);
     unsigned defaultNetId = appDefaultNetwork ? appDefaultNetwork->getNetId() : mDefaultNetId;
@@ -248,6 +248,7 @@ uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) c
         VirtualNetwork* virtualNetwork = getVirtualNetworkForUserLocked(uid);
         if (virtualNetwork && resolv_has_nameservers(virtualNetwork->getNetId())) {
             *netId = virtualNetwork->getNetId();
+            fwmark.explicitlySelected = true;
         } else {
             // TODO: return an error instead of silently doing the DNS lookup on the wrong network.
             // http://b/27560555

--- a/server/NetworkController.cpp
+++ b/server/NetworkController.cpp
@@ -208,6 +208,7 @@ int NetworkController::setDefaultNetwork(unsigned netId) {
 }
 
 uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) const {
+    ALOGE("getNetworkForDnsLocked, uid: %u, netId: %u", uid, *netId);
     Fwmark fwmark;
     fwmark.protectedFromVpn = canProtectLocked(uid, *netId);
     fwmark.permission = getPermissionForUserLocked(uid);
@@ -221,6 +222,7 @@ uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) c
     // majority of DNS queries.
     // TODO: untangle this code.
     if (*netId == NETID_UNSET && getVirtualNetworkForUserLocked(uid) == nullptr) {
+        ALOGE("getNetworkForDnsLocked path0");
         *netId = defaultNetId;
         fwmark.netId = *netId;
         fwmark.explicitlySelected = true;
@@ -228,6 +230,7 @@ uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) c
     }
 
     if (checkUserNetworkAccessLocked(uid, *netId) == 0) {
+        ALOGE("getNetworkForDnsLocked path1");
         // If a non-zero NetId was explicitly specified, and the user has permission for that
         // network, use that network's DNS servers. (possibly falling through the to the default
         // network if the VPN doesn't provide a route to them).
@@ -238,18 +241,22 @@ uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) c
         // http://b/29498052
         Network *network = getNetworkLocked(*netId);
         if (network && network->isVirtual() && !resolv_has_nameservers(*netId)) {
+            ALOGE("getNetworkForDnsLocked path1a");
             *netId = defaultNetId;
         }
     } else {
+        ALOGE("getNetworkForDnsLocked path2");
         // If the user is subject to a VPN and the VPN provides DNS servers, use those servers
         // (possibly falling through to the default network if the VPN doesn't provide a route to
         // them). Otherwise, use the default network's DNS servers.
         // TODO: Consider if we should set the explicit bit here.
         VirtualNetwork* virtualNetwork = getVirtualNetworkForUserLocked(uid);
         if (virtualNetwork && resolv_has_nameservers(virtualNetwork->getNetId())) {
+            ALOGE("getNetworkForDnsLocked path2a");
             *netId = virtualNetwork->getNetId();
             fwmark.explicitlySelected = true;
         } else {
+            ALOGE("getNetworkForDnsLocked path2b");
             // TODO: return an error instead of silently doing the DNS lookup on the wrong network.
             // http://b/27560555
             *netId = defaultNetId;

--- a/server/NetworkController.cpp
+++ b/server/NetworkController.cpp
@@ -224,8 +224,6 @@ uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) c
         *netId = defaultNetId;
         fwmark.netId = *netId;
         fwmark.explicitlySelected = true;
-        fwmark.protectedFromVpn = canProtectLocked(uid, *netId);
-        fwmark.permission = getPermissionForUserLocked(uid);
         return fwmark.intValue;
     }
 
@@ -242,11 +240,6 @@ uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) c
         if (network && network->isVirtual() && !resolv_has_nameservers(*netId)) {
             *netId = defaultNetId;
         }
-
-        if (!network || !network->isVirtual() || !resolv_has_nameservers(*netId)) {
-            fwmark.protectedFromVpn = canProtectLocked(uid, *netId);
-            fwmark.permission = getPermissionForUserLocked(uid);
-        }
     } else {
         // If the user is subject to a VPN and the VPN provides DNS servers, use those servers
         // (possibly falling through to the default network if the VPN doesn't provide a route to
@@ -259,8 +252,6 @@ uint32_t NetworkController::getNetworkForDnsLocked(unsigned* netId, uid_t uid) c
             // TODO: return an error instead of silently doing the DNS lookup on the wrong network.
             // http://b/27560555
             *netId = defaultNetId;
-            fwmark.protectedFromVpn = canProtectLocked(uid, *netId);
-            fwmark.permission = getPermissionForUserLocked(uid);
         }
     }
     fwmark.netId = *netId;


### PR DESCRIPTION
In the original solution, the path that had to be loosened to prevent compat issues actually had a bug. This bug results in DNS requests by the VPN app itself going out over the physical interface instead of the tun interface. This fix is needed to prevent leaks in the original solution, but could also be what is causing the compat issue. It's not guaranteed to be the case, but we should at least confirm that the proper solution causes compat issues before moving on to the compat toggle.